### PR TITLE
Add access_token_cache_key arg to client for caching access tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 Gemfile.lock
 *.gem
 .ruby-version
+.byebug_history

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 1.4.0
+
+- Pass cache key to client for caching access tokens [#11](https://github.com/patterninc/muffin_man/pull/11)

--- a/README.md
+++ b/README.md
@@ -40,11 +40,14 @@ credentials = {
   aws_secret_access_key: AWS_SECRET_ACCESS_KEY,
   region: REGION, # This can be one of ['na', 'eu', 'fe'] and defaults to 'na'
   sts_iam_role_arn: STS_IAM_ROLE_ARN, # Optional
+  access_token_cache_key: SELLING_PARTNER_ID, # Optional if you want access token caching
 }
 client = MuffinMan::Solicitations::V1.new(credentials)
 response = client.create_product_review_and_seller_feedback_solicitation(amazon_order_id, marketplace_ids)
 JSON.parse(response.body)
 ```
+
+### Access Token Caching
 
 You can optionally use Amazon's sandbox environment by specifying `client = MuffinMan::Solicitations.new(credentials, sandbox = true)`
 
@@ -55,11 +58,11 @@ For example, if you are using Redis as your cache you could define:
 ```ruby
 @@redis = Redis.new
 MuffinMan.configure do |config|
-  config.save_access_token = -> (client_id, token) do
-    @@redis.set("SP-TOKEN-#{client_id}", token['access_token'], ex: token['expires_in'])
+  config.save_access_token = -> (access_token_cache_key, token) do
+    @@redis.set("SP-TOKEN-#{access_token_cache_key}", token['access_token'], ex: token['expires_in'])
   end
 
-  config.get_access_token = -> (client_id) { @@redis.get("SP-TOKEN-#{client_id}") }
+  config.get_access_token = -> (access_token_cache_key) { @@redis.get("SP-TOKEN-#{access_token_cache_key}") }
 end
 ```
 

--- a/lib/muffin_man/version.rb
+++ b/lib/muffin_man/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MuffinMan
-  VERSION = "1.3.0"
+  VERSION = "1.4.0"
 end

--- a/muffin_man.gemspec
+++ b/muffin_man.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rspec", "~> 3.2"
   spec.add_development_dependency 'webmock', '~> 2.1'
+  spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'mock_redis', '>=0.14'
   spec.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
   spec.add_runtime_dependency 'aws-sigv4', '>= 1.1'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require "muffin_man"
 require "webmock/rspec"
 require "support/sp_api_helpers"
 require "support/lwa_helpers"
+require "byebug"
 
 WebMock.disable_net_connect!(allow_localhost: true)
 


### PR DESCRIPTION
The same client_id can be used for multiple selling accounts so
allow specifying what key to use for caching.