### PR TITLE
add support for product_pricing's get_get_competitive_pricing endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ As of now, this gem only supports portions of the following APIs with more to co
 - `create_product_review_and_seller_feedback_solicitation`
 - `catalog_items`
 - `reports`
+- `product_pricing`
 
 ## Installation
 

--- a/lib/muffin_man.rb
+++ b/lib/muffin_man.rb
@@ -8,6 +8,7 @@ require "muffin_man/catalog_items/v20201201"
 require "muffin_man/finances/v0"
 require "muffin_man/authorization/v1"
 require "muffin_man/tokens/v20210301"
+require "muffin_man/product_pricing/v0"
 
 module MuffinMan
   class Error < StandardError; end

--- a/lib/muffin_man/product_pricing/v0.rb
+++ b/lib/muffin_man/product_pricing/v0.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module MuffinMan
+  module ProductPricing
+    class V0 < SpApiClient
+      GET_COMPETITIVE_PRICE_PARAMS = %w[Asins Skus CustomerType].freeze
+
+      def get_competitive_pricing(marketplace_id, item_type='Asin', params = {})
+        @marketplace_id = marketplace_id
+        @item_type = item_type
+        @params = params
+        @local_var_path = "/products/pricing/v0/competitivePrice"
+        @query_params = { "MarketplaceId" => @marketplace_id,
+                          "ItemType" => @item_type }
+        @query_params.merge!(@params.slice(*GET_COMPETITIVE_PRICE_PARAMS))
+        @request_type = "GET"
+        call_api
+      end
+    end
+  end
+end

--- a/spec/muffin_man/product_pricing_spec.rb
+++ b/spec/muffin_man/product_pricing_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe MuffinMan::ProductPricing::V0 do
+  before do
+    stub_request_access_token
+    stub_get_competitive_pricing
+  end
+  let(:amazon_marketplace_id) { "ATVPDKIKX0DER" }
+  let(:item_type) { "Asin" }
+  let(:asin) { "B09WZ936D8" }
+
+  subject(:product_pricing_client) { described_class.new(credentials) }
+
+  describe "get_competitive_pricing" do
+    it "makes a get_competitive_pricing request to amazon" do
+      response = product_pricing_client.get_competitive_pricing(amazon_marketplace_id, item_type, {'Asins' => asin})
+      expect(response.response_code).to eq(200)
+      expect(JSON.parse(response.body)["payload"][0]['status']).to eq("Success")
+    end
+  end
+end

--- a/spec/support/get_competitive_pricing.json
+++ b/spec/support/get_competitive_pricing.json
@@ -1,0 +1,72 @@
+{
+  "payload": [
+    {
+      "ASIN": "B09WZ936D8",
+      "Product": {
+        "CompetitivePricing": {
+          "CompetitivePrices": [
+            {
+              "belongsToRequester": false,
+              "condition": "New",
+              "subcondition": "New",
+              "Price": {
+                "LandedPrice": {
+                  "CurrencyCode": "USD",
+                  "Amount": 149.96
+                },
+                "ListingPrice": {
+                  "CurrencyCode": "USD",
+                  "Amount": 149.96
+                },
+                "Shipping": {
+                  "CurrencyCode": "USD",
+                  "Amount": 0
+                }
+              },
+              "CompetitivePriceId": "1"
+            }
+          ],
+          "NumberOfOfferListings": [
+            {
+              "condition": "New",
+              "Count": 5
+            },
+            {
+              "condition": "Used",
+              "Count": 1
+            },
+            {
+              "condition": "Any",
+              "Count": 6
+            }
+          ]
+        },
+        "Identifiers": {
+          "MarketplaceASIN": {
+            "MarketplaceId": "ATVPDKIKX0DER",
+            "ASIN": "B09WZ936D8"
+          }
+        },
+        "SalesRankings": [
+          {
+            "ProductCategoryId": "kitchen_display_on_website",
+            "Rank": 73806
+          },
+          {
+            "ProductCategoryId": "289819",
+            "Rank": 78
+          },
+          {
+            "ProductCategoryId": "kitchen_display_on_website",
+            "Rank": 73806
+          },
+          {
+            "ProductCategoryId": "289819",
+            "Rank": 78
+          }
+        ]
+      },
+      "status": "Success"
+    }
+  ]
+}

--- a/spec/support/sp_api_helpers.rb
+++ b/spec/support/sp_api_helpers.rb
@@ -128,6 +128,10 @@ module Support
         .to_return(status: 200, body: body, headers: {})
     end
 
+    def stub_get_competitive_pricing
+      stub_request(:get, "https://#{hostname}/products/pricing/v0/competitivePrice?Asins=#{asin}&ItemType=#{item_type}&MarketplaceId=#{amazon_marketplace_id}")
+        .to_return(status: 200, body: File.read("./spec/support/get_competitive_pricing.json"), headers: {})
+    end
     def credentials
       {
         refresh_token: "a-refresh-token",


### PR DESCRIPTION
Code

Add endpoint to support fetching competitive pricing for an ASINs

Tests
Add spec for product_pricing get_get_competitive_pricing
`rspec spec/muffin_man/product_pricing_spec.rb`

**Ticket **
https://app.clickup.com/t/2323726/CORE-8404