### PR TITLE
Use Aws Credentials for STS token to override global config

### DIFF
--- a/lib/muffin_man/sp_api_client.rb
+++ b/lib/muffin_man/sp_api_client.rb
@@ -126,8 +126,7 @@ module MuffinMan
     def request_sts_token
       client = Aws::STS::Client.new(
         region: derive_aws_region,
-        access_key_id: aws_access_key_id,
-        secret_access_key: aws_secret_access_key,
+        credentials: Aws::Credentials.new(aws_access_key_id, aws_secret_access_key),
         http_wire_trace: (ENV["AWS_DEBUG"] == "true" || false)
       )
       client.assume_role(role_arn: sts_iam_role_arn, role_session_name: SecureRandom.uuid)


### PR DESCRIPTION
Some clever detective work from @landiinii:

"According to the [documentation for the initializer](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/Firehose/Client.html#:~:text=When%20%3Acredentials%20are%20not%20configured%20directly%2C%20the%20following%20locations%20will%20be%20searched%20for%20credentials%3A) of the AWS::STS ruby client, this client will look to the global AWS.config credentials before looking to the directly passed :access_key_id and :secret_access_key"