### PR TITLE
Fixes for catalog items 20220401

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.4.14
+
+- Fixes for catalogItems API [#32](https://github.com/patterninc/muffin_man/pull/32)
+
 # 1.4.13
 
 - Support for updateInboundShipment [#28](https://github.com/patterninc/muffin_man/pull/28)
@@ -12,7 +16,7 @@
 
 # 1.4.10
 
-- Support for getShipments  [#27](https://github.com/patterninc/muffin_man/pull/27)
+- Support for getShipments [#27](https://github.com/patterninc/muffin_man/pull/27)
 
 # 1.4.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1.4.14
 
-- Fixes for catalogItems API [#32](https://github.com/patterninc/muffin_man/pull/32)
+- Fixes for catalogItems API. Removes `keywords` variable requirement for v20220401 [#32](https://github.com/patterninc/muffin_man/pull/32)
 
 # 1.4.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# 1.4.14
+# 1.5.0
 
-- Fixes for catalogItems API. Removes `keywords` variable requirement for v20220401 [#32](https://github.com/patterninc/muffin_man/pull/32)
+- [#32](https://github.com/patterninc/muffin_man/pull/32)
+- Removes `keywords` variable requirement for v20220401 search_catalog_items as it is not required in v20220401. You'll need to pass `keywords` as a param rather than as an argument for the method
 
 # 1.4.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # 1.5.0
 
-- [#32](https://github.com/patterninc/muffin_man/pull/32)
-- Removes `keywords` variable requirement for v20220401 search_catalog_items as it is not required in v20220401. You'll need to pass `keywords` as a param rather than as an argument for the method
+## Breaking changes - 1. v20220401 search_catalog_items method signature updated
+
+- [#32](https://github.com/patterninc/muffin_man/pull/32) Removes `keywords` argument requirement for v20220401 search_catalog_items as it is not required in v20220401. You'll need to pass `keywords` as a param rather than as an argument for the method
 
 # 1.4.13
 

--- a/lib/muffin_man/catalog_items/base_api.rb
+++ b/lib/muffin_man/catalog_items/base_api.rb
@@ -6,7 +6,8 @@ module MuffinMan
       SANDBOX_MARKETPLACE_IDS = "ATVPDKIKX0DER".freeze
       attr_reader :keywords, :asin, :marketplace_ids, :params
 
-      SEARCH_CATALOG_ITEMS_PARAMS = %w[
+      SEARCH_CATALOG_ITEMS_PARAMS = [].freeze
+      BASE_SEARCH_CATALOG_ITEMS_PARAMS = %w[
         includedData
         brandNames
         classificationIds
@@ -30,10 +31,10 @@ module MuffinMan
         @params = params
         @local_var_path = "/catalog/#{api_version}/items"
         @query_params = {
-          "keywords" => @keywords.join(","),
           "marketplaceIds" => @marketplace_ids.join(",")
         }
-        @query_params.merge!(@params.slice(*SEARCH_CATALOG_ITEMS_PARAMS))
+        @query_params["keywords"] = @keywords.join(",") if @keywords.any?
+        @query_params.merge!(@params.slice(*search_catalog_items_params))
         @request_type = "GET"
         call_api
       end
@@ -52,6 +53,12 @@ module MuffinMan
         @query_params.merge!(@params.slice(*GET_CATALOG_ITEM_PARAMS))
         @request_type = "GET"
         call_api
+      end
+
+      private
+
+      def search_catalog_items_params
+        BASE_SEARCH_CATALOG_ITEMS_PARAMS + self.class::SEARCH_CATALOG_ITEMS_PARAMS
       end
     end
   end

--- a/lib/muffin_man/catalog_items/v20220401.rb
+++ b/lib/muffin_man/catalog_items/v20220401.rb
@@ -3,11 +3,16 @@ require "muffin_man/catalog_items/base_api"
 module MuffinMan
   module CatalogItems
     class V20220401 < BaseApi
+      SEARCH_CATALOG_ITEMS_PARAMS = %w(
+        identifiers
+        identifiersType
+        sellerId
+      ).freeze
 
       API_VERSION = "2022-04-01".freeze
 
-      def search_catalog_items(keywords, marketplace_ids, params = {})
-        super(keywords, marketplace_ids, params, API_VERSION)
+      def search_catalog_items(marketplace_ids, params = {})
+        super(params[:keywords], marketplace_ids, params, API_VERSION)
       end
 
       def get_catalog_item(asin, marketplace_ids, params = {})

--- a/lib/muffin_man/catalog_items/v20220401.rb
+++ b/lib/muffin_man/catalog_items/v20220401.rb
@@ -12,7 +12,7 @@ module MuffinMan
       API_VERSION = "2022-04-01".freeze
 
       def search_catalog_items(marketplace_ids, params = {})
-        super(params[:keywords], marketplace_ids, params, API_VERSION)
+        super(params["keywords"], marketplace_ids, params, API_VERSION)
       end
 
       def get_catalog_item(asin, marketplace_ids, params = {})

--- a/lib/muffin_man/version.rb
+++ b/lib/muffin_man/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MuffinMan
-  VERSION = "1.4.13"
+  VERSION = "1.4.14"
 end

--- a/lib/muffin_man/version.rb
+++ b/lib/muffin_man/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MuffinMan
-  VERSION = "1.4.14"
+  VERSION = "1.5.0"
 end

--- a/spec/muffin_man/catalog_items_v20220401_spec.rb
+++ b/spec/muffin_man/catalog_items_v20220401_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe MuffinMan::CatalogItems::V20220401 do
 
   describe "search_catalog_items" do
     it "makes a search_catalog_items request to amazon" do
-      response = catalog_items_client.search_catalog_items(amazon_marketplace_id, { keywords: keywords})
+      response = catalog_items_client.search_catalog_items(amazon_marketplace_id, { "keywords" => keywords})
       response_body = JSON.parse(response.body)
       expect(response.response_code).to eq(200)
       expect(response_body.keys).to include("items")

--- a/spec/muffin_man/catalog_items_v20220401_spec.rb
+++ b/spec/muffin_man/catalog_items_v20220401_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe MuffinMan::CatalogItems::V20220401 do
 
   describe "search_catalog_items" do
     it "makes a search_catalog_items request to amazon" do
-      response = catalog_items_client.search_catalog_items(keywords, amazon_marketplace_id)
+      response = catalog_items_client.search_catalog_items(amazon_marketplace_id, { keywords: keywords})
       response_body = JSON.parse(response.body)
       expect(response.response_code).to eq(200)
       expect(response_body.keys).to include("items")


### PR DESCRIPTION
Allow `identifiers`, `identifiersType`, and `sellerId` parameters to be passed for catalog items 20220401.

Remove `keywords` requirement from catalog items v20220401 as it is no longer a required parameter