### PR TITLE
Report request body reset

### DIFF
--- a/lib/muffin_man/reports/v20210630.rb
+++ b/lib/muffin_man/reports/v20210630.rb
@@ -57,6 +57,7 @@ module MuffinMan
         report_id = sandbox ? SANDBOX_REPORT_ID : report_id
         @local_var_path = "/reports/2021-06-30/reports/#{report_id}"
         @request_type = "GET"
+        @request_body = nil
         call_api
       end
 

--- a/lib/muffin_man/sp_api_client.rb
+++ b/lib/muffin_man/sp_api_client.rb
@@ -49,7 +49,7 @@ module MuffinMan
 
     def request_opts
       opts = { headers: headers }
-      opts[:body] = request_body.to_json if request_body
+      opts[:body] = request_body.to_json if request_body && request_type != "GET" && request_type != "HEAD"
       opts
     end
 


### PR DESCRIPTION
When a client is initialized for the `Reports::V20210630` a common sequence of function calls for a user is to first call the `create_report` function which passes a request body in POST request to amazon to initialize a report's creation. The user will then very commonly use the same instance of `Reports::V20210630` to call the `get_report` function which uses a GET request to update the user on the status of the reports creation. However, since the same instance of `Reports::V20210630` was used for both requests, that second GET request will incorrectly pass the request body of the first POST request as its own body since that request_body is saved as an instance variable on the class level. Previously this would not have been a problem, because the GET request would just ignore the body passed with it, but beginning June 5th 2023 Amazon is enforcing [HTTP RFC 7230](https://datatracker.ietf.org/doc/html/rfc7230) requirements on all of their incoming requests. This includes, as mentioned in [their announcement for this enforcement change](https://developer-docs.amazon.com/sp-api/changelog/api-request-validation-for-400-errors-with-html-response), restrictions on the "presence of body or Content-Length header for GET/HEAD requests." So the passing of the previous request body to the second GET request would violate the restriction and result in a 400 response.

This PR intends to correct the current logic in order to accommodate the common user flow of using the same client instance to make both a create_report and get_report function call with the new requirements of following RFC 7230 protocols.