### PR TITLE
Added validations on keywords & identifiers for search catalog_items API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1.1 [#62](https://github.com/patterninc/muffin_man/pull/62)
+
+- SearchCatalogItems validations on keywords & identifiers
+
 # 2.1.0 [#58](https://github.com/patterninc/muffin_man/pull/58)
 
 - Support for Product Type Definitions

--- a/lib/muffin_man/catalog_items/base_api.rb
+++ b/lib/muffin_man/catalog_items/base_api.rb
@@ -30,6 +30,7 @@ module MuffinMan
         end
         @keywords = keywords.is_a?(Array) ? keywords : [keywords]
         @identifiers = params["identifiers"].is_a?(Array) ? params["identifiers"] : [params["identifiers"]]
+        validate_keywords_and_identifiers
         @marketplace_ids = marketplace_ids.is_a?(Array) ? marketplace_ids : [marketplace_ids]
         @params = params
         @local_var_path = "/catalog/#{api_version}/items"
@@ -67,6 +68,11 @@ module MuffinMan
 
       def search_catalog_items_params
         BASE_SEARCH_CATALOG_ITEMS_PARAMS + self.class::SEARCH_CATALOG_ITEMS_PARAMS
+      end
+
+      def validate_keywords_and_identifiers
+        raise MuffinMan::Error, "Keywords cannot be used with Identifiers" if @keywords.any? && @identifiers.any?
+        raise MuffinMan::Error, "Keywords or Identifiers must be present" if @keywords.none? && @identifiers.none?
       end
     end
   end

--- a/lib/muffin_man/version.rb
+++ b/lib/muffin_man/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MuffinMan
-  VERSION = "2.1.0"
+  VERSION = "2.1.1"
 end

--- a/spec/muffin_man/catalog_items_v20220401_spec.rb
+++ b/spec/muffin_man/catalog_items_v20220401_spec.rb
@@ -31,6 +31,25 @@ RSpec.describe MuffinMan::CatalogItems::V20220401 do
     end
   end
 
+  describe "search_catalog_items_validate_keywords_and_identifiers" do
+    context "when neither keywords nor identifiers are present" do
+      it "raises MuffinMan::Error" do
+        expect do
+          catalog_items_client.search_catalog_items(amazon_marketplace_id, {})
+        end.to raise_error(MuffinMan::Error, "Keywords or Identifiers must be present")
+      end
+    end
+
+    context "when both keywords and identifiers are present" do
+      it "raises MuffinMan::Error" do
+        expect do
+          catalog_items_client.search_catalog_items(amazon_marketplace_id,
+                                                    { "keywords" => keywords, "identifiers" => asins })
+        end.to raise_error(MuffinMan::Error, "Keywords cannot be used with Identifiers")
+      end
+    end
+  end
+
   describe "get_catalog_item" do
     it "makes a get_catalog_item request to amazon" do
       response = catalog_items_client.get_catalog_item(asin, amazon_marketplace_id)


### PR DESCRIPTION
**Current Behaviour** -
- For SearchCatalogItems API, if we send keywords and identifiers both the values then we calling SPAPI and getting error from that API that is `Invalid combination of 'identifiers' and 'keywords' provided`. This is because the API support either of these values and not both.
- Also, if we don't send any of these two values to the API then we are getting error from SPAPI that is `Missing required 'identifiers' or 'keywords'.`

**Problem Statement** -
- This gem should avoid such API calls to SPAPI if the expected parameters are missing.

**Proposed Solution** - 
- We are adding validations on keywords and identifiers in this gem and avoid SPAPI API call and return error from the gem only.
