### PR TITLE
Make request public

### DIFF
--- a/lib/muffin_man/sp_api_client.rb
+++ b/lib/muffin_man/sp_api_client.rb
@@ -39,6 +39,10 @@ module MuffinMan
       @config = MuffinMan.configuration
     end
 
+    def request
+      Typhoeus::Request.new(canonical_uri, params: query_params)
+    end
+
     private
 
     def call_api
@@ -71,10 +75,6 @@ module MuffinMan
     def canonical_uri
       # local_var_path is defined in subclasses
       "#{sp_api_url}#{local_var_path}"
-    end
-
-    def request
-      Typhoeus::Request.new(canonical_uri, params: query_params)
     end
 
     def retrieve_lwa_access_token

--- a/lib/muffin_man/version.rb
+++ b/lib/muffin_man/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MuffinMan
-  VERSION = "2.4.8"
+  VERSION = "2.4.9"
 end


### PR DESCRIPTION
We found a use case where it was helpful to have this. Making it public so it is available without having to use `:send`