### PR TITLE
Add support for Listing Preview Validation

### DIFF
--- a/lib/muffin_man/listings/v20210801.rb
+++ b/lib/muffin_man/listings/v20210801.rb
@@ -21,13 +21,15 @@ module MuffinMan
       end
 
       def put_listings_item(seller_id, sku, marketplace_ids, product_type, attributes, issue_locale: nil,
-                            requirements: nil)
+                            requirements: nil, mode: nil, included_data: [])
         @local_var_path = "/listings/2021-08-01/items/#{seller_id}/#{sku}"
         @marketplace_ids = marketplace_ids.is_a?(Array) ? marketplace_ids : [marketplace_ids]
         @query_params = {
           "marketplaceIds" =>  @marketplace_ids.join(",")
         }
         @query_params["issueLocale"] = issue_locale if issue_locale
+        @query_params["includedData"] = included_data.join(",") if included_data.any?
+        @query_params["mode"] = mode if mode
         @request_body = {
           "productType" => product_type,
           "attributes" => attributes

--- a/spec/muffin_man/listings/v20210801_spec.rb
+++ b/spec/muffin_man/listings/v20210801_spec.rb
@@ -32,32 +32,78 @@ RSpec.describe MuffinMan::Listings::V20210801 do
   end
 
   describe "put_listings_item" do
-    before { stub_put_listings_item }
+    context "when creating or updating a full listing item" do
+      before { stub_put_listings_item }
 
-    let(:requirements) { "LISTING" }
-    let(:attributes) do
-      {
-        condition_type: [
-          {
-            value: "new_new",
-            marketplace_id: "ATVPDKIKX0DER"
-          }
-        ],
-        item_name: [
-          {
-            value: "AmazonBasics 16\" Underseat Spinner Carry-On",
-            language_tag: "en_US",
-            marketplace_id: "ATVPDKIKX0DER"
-          }
-        ]
-      }
+      let(:requirements) { "LISTING" }
+      let(:attributes) do
+        {
+          condition_type: [
+            {
+              value: "new_new",
+              marketplace_id: "ATVPDKIKX0DER"
+            }
+          ],
+          item_name: [
+            {
+              value: "AmazonBasics 16\" Underseat Spinner Carry-On",
+              language_tag: "en_US",
+              marketplace_id: "ATVPDKIKX0DER"
+            }
+          ]
+        }
+      end
+
+      it "returns an ACCEPTED status" do
+        response = listings_client.put_listings_item(seller_id, sku, amazon_marketplace_id, product_type, attributes,
+                                                     requirements: requirements)
+        expect(response.response_code).to eq(200)
+        expect(JSON.parse(response.body)).to eq(submission_accepted_response)
+      end
     end
 
-    it "makes a request to create a listings item or update an existing listings item" do
-      response = listings_client.put_listings_item(seller_id, sku, amazon_marketplace_id, product_type, attributes,
-                                                   requirements: requirements)
-      expect(response.response_code).to eq(200)
-      expect(JSON.parse(response.body)).to eq(submission_accepted_response)
+    context "when previewing validation for a listings item" do
+      before { stub_put_listings_item_preview }
+
+      let(:requirements) { "LISTING_OFFER_ONLY" }
+      let(:attributes) do
+        {
+          condition_type: [
+            {
+              value: "new_new",
+              marketplace_id: "ATVPDKIKX0DER"
+            }
+          ],
+          item_name: [
+            {
+              value: "AmazonBasics 16\" Underseat Spinner Carry-On",
+              language_tag: "en_US",
+              marketplace_id: "ATVPDKIKX0DER"
+            }
+          ],
+          identifiers: [
+            {
+              asin: "B987654321",
+              marketplaceId: "ATVPDKIKX0DER"
+            }
+          ]
+        }
+      end
+
+      #     PUT https://sellingpartnerapi-na.amazon.com/listings/2021-08-01/items/AXXXXXXXXXXXXX/ABC123
+      # ?marketplaceIds=ATVPDKIKX0DER
+      # &issueLocale=en_US
+      # &mode=VALIDATION_PREVIEW
+      # &includedData=issues,identifiers
+
+      it "returns a VALIDATED status" do
+        response = listings_client.put_listings_item(seller_id, sku,
+                                                     amazon_marketplace_id, product_type, attributes,
+                                                     requirements: requirements, mode: "VALIDATION_PREVIEW",
+                                                     included_data: ["issues", "identifiers"], issue_locale: "en_US")
+        expect(response.response_code).to eq(200)
+        expect(JSON.parse(response.body)["status"]).to eq("VALID")
+      end
     end
   end
 

--- a/spec/muffin_man/listings/v20210801_spec.rb
+++ b/spec/muffin_man/listings/v20210801_spec.rb
@@ -90,12 +90,6 @@ RSpec.describe MuffinMan::Listings::V20210801 do
         }
       end
 
-      #     PUT https://sellingpartnerapi-na.amazon.com/listings/2021-08-01/items/AXXXXXXXXXXXXX/ABC123
-      # ?marketplaceIds=ATVPDKIKX0DER
-      # &issueLocale=en_US
-      # &mode=VALIDATION_PREVIEW
-      # &includedData=issues,identifiers
-
       it "returns a VALIDATED status" do
         response = listings_client.put_listings_item(seller_id, sku,
                                                      amazon_marketplace_id, product_type, attributes,

--- a/spec/support/put_listings_item_preview.json
+++ b/spec/support/put_listings_item_preview.json
@@ -1,0 +1,12 @@
+{
+  "sku": "ABC123",
+  "status": "VALID",
+  "submissionId": "65793a6142784e36b39af92b736a3a9f",
+  "issues": [],
+  "identifiers": [
+    {
+      "marketplaceId": "ATVPDKIKX0DER",
+      "asin": "B987654321"
+    }
+  ]
+}

--- a/spec/support/sp_api_helpers.rb
+++ b/spec/support/sp_api_helpers.rb
@@ -235,6 +235,11 @@ module Support
         .to_return(status: 200, body: File.read("./spec/support/put_listings_item.json"), headers: {})
     end
 
+    def stub_put_listings_item_preview
+      stub_request(:put, "https://#{hostname}/listings/2021-08-01/items/#{seller_id}/#{sku}?includedData=issues,identifiers&issueLocale=en_US&marketplaceIds=DRURYLANE&mode=VALIDATION_PREVIEW")
+        .to_return(status: 200, body: File.read("./spec/support/put_listings_item_preview.json"), headers: {})
+    end
+
     def stub_delete_listings_item
       stub_request(:delete, "https://#{hostname}/listings/2021-08-01/items/#{seller_id}/#{sku}?marketplaceIds=#{amazon_marketplace_id}&issueLocale=#{issue_locale}")
         .to_return(status: 200, body: File.read("./spec/support/delete_listings_item.json"), headers: {})


### PR DESCRIPTION
The [put_listings_item](https://github.com/patterninc/muffin_man/blob/66f1d191afdc6ab4095dbefb4378c0bf77f6f254/lib/muffin_man/listings/v20210801.rb#L23) method was missing support for validation preview functionality.   Added optional parameters for :mode and :included_data to expand the method functionality.  It is a non-breaking change for existing gem users.