### PR TITLE
Remove AWS STS Signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.4.13
+
+- Remove AWS STS Signature in requests [#97](https://github.com/patterninc/muffin_man/pull/97)
+
 # 2.4.12
 
 - [#95](https://github.com/patterninc/muffin_man/pull/95)

--- a/README.md
+++ b/README.md
@@ -66,10 +66,7 @@ credentials = {
   refresh_token: LWA_REFRESH_TOKEN,
   client_id: CLIENT_ID,
   client_secret: CLIENT_SECRET,
-  aws_access_key_id: AWS_ACCESS_KEY_ID,
-  aws_secret_access_key: AWS_SECRET_ACCESS_KEY,
   region: REGION, # This can be one of ['na', 'eu', 'fe'] and defaults to 'na'
-  sts_iam_role_arn: STS_IAM_ROLE_ARN, # Optional
   access_token_cache_key: SELLING_PARTNER_ID, # Optional if you want access token caching
 }
 client = MuffinMan::Solicitations::V1.new(credentials)
@@ -115,9 +112,6 @@ To retrieve the refresh token from an LWA Website authorization workflow, you ca
 credentials = {
   client_id: CLIENT_ID,
   client_secret: CLIENT_SECRET,
-  aws_access_key_id: AWS_ACCESS_KEY_ID,
-  aws_secret_access_key: AWS_SECRET_ACCESS_KEY,
-  sts_iam_role_arn: STS_IAM_ROLE_ARN, # Optional
   scope: 'sellingpartnerapi::migration' # Grantless scope for MWS migration
 }
 client = MuffinMan::Authorization::V1.new(credentials)

--- a/spec/support/sp_api_helpers.rb
+++ b/spec/support/sp_api_helpers.rb
@@ -523,9 +523,7 @@ module Support
       {
         refresh_token: "a-refresh-token",
         client_id: "a-client-id",
-        client_secret: "a-client-secret",
-        aws_access_key_id: "an-aws-access-key-id",
-        aws_secret_access_key: "an-aws-secret-access-key"
+        client_secret: "a-client-secret"
       }
     end
 


### PR DESCRIPTION
Since October 2023 SP-API has been ignoring the signature included in request headers.

https://developer-docs.amazon.com/sp-api/changelog/sp-api-will-no-longer-require-aws-iam-or-aws-signature-version-4