### PR TITLE
corrected the query params for sp api client

### DIFF
--- a/lib/muffin_man/finances/v20240619.rb
+++ b/lib/muffin_man/finances/v20240619.rb
@@ -8,7 +8,7 @@ module MuffinMan
         @query_params = {
           "postedAfter" => posted_after
         }
-        @query_params["PostedBefore"] = posted_before unless posted_before.nil?
+        @query_params["postedBefore"] = posted_before unless posted_before.nil?
         @query_params["marketplaceId"] = marketplace_id unless marketplace_id.nil?
         @query_params["nextToken"] = next_token unless next_token.nil?
         @request_type = "GET"


### PR DESCRIPTION
Correct the query param variable for sp-api client

query param should be `postedBefore` instead of PostedBefore

Referenece:
https://developer-docs.amazon.com/sp-api/docs/finances-api-v2024-06-19-use-case-guide#step-2-identify-the-appropriate-financialeventgroupid

API Provided by amazon:
`GET /finances/2024-06-19/transactions?postedAfter=2023-07-26&postedBefore=2023-09-16`
